### PR TITLE
Log last_record.head and tail

### DIFF
--- a/src/log/history.rs
+++ b/src/log/history.rs
@@ -103,7 +103,10 @@ impl LogHistory {
                 // 新しい選挙期間(`Term`)に移った
                 track_assert!(
                     self.last_record().head.prev_term < tail.prev_term,
-                    ErrorKind::Other
+                    ErrorKind::Other,
+                    "last_record.head={:?}, tail={:?}",
+                    self.last_record().head,
+                    tail
                 );
                 let record = HistoryRecord::new(tail, self.last_record().config.clone());
                 self.records.push_back(record);


### PR DESCRIPTION
修正箇所の `track_assert!` で term が異常な値になっているログが出ているので、具体的にどのような値だったのかが分かるようにログを追加したい。