### PR TITLE
Gathers metrics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raftlog"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["The FrugalOS Developers"]
 description = "An implementation of distributed replicated log based on the Raft algorithm"
 homepage = "https://github.com/frugalos/raftlog"
@@ -16,6 +16,7 @@ travis-ci = {repository = "frugalos/raftlog"}
 [dependencies]
 futures = "0.1"
 trackable = "0.2"
+prometrics = "0.1"
 
 [dev-dependencies]
 fibers = "0.1"

--- a/raftlog_simu/Cargo.toml
+++ b/raftlog_simu/Cargo.toml
@@ -10,6 +10,7 @@ futures = "0.1"
 serde = "1"
 serde_derive = "1"
 serdeconv = "0.3"
+prometrics = "0.1"
 raftlog = { path = "../" }
 rand = "0.5"
 trackable = "0.2"

--- a/raftlog_simu/src/lib.rs
+++ b/raftlog_simu/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate futures;
+extern crate prometrics;
 extern crate raftlog;
 extern crate rand;
 extern crate serde;

--- a/raftlog_simu/src/process.rs
+++ b/raftlog_simu/src/process.rs
@@ -1,5 +1,6 @@
 //! シミュレータ上で動作するプロセス.
 use futures::{Async, Future, Poll, Stream};
+use prometrics::metrics::MetricBuilder;
 use raftlog::cluster::ClusterMembers;
 use raftlog::log::{LogEntry, LogIndex, ProposalId};
 use raftlog::message::SequenceNumber;
@@ -249,8 +250,9 @@ impl Alive {
         members: ClusterMembers,
         io: DeterministicIo,
     ) -> Self {
+        let metric_builder = MetricBuilder::new();
         let machine = MachineState::new();
-        let rlog = ReplicatedLog::new(node_id, members, io);
+        let rlog = ReplicatedLog::new(node_id, members, io, &metric_builder).expect("Never fails");
         Alive {
             logger,
             machine,
@@ -266,8 +268,9 @@ impl Alive {
         old_members: ClusterMembers,
         io: DeterministicIo,
     ) -> Self {
+        let metric_builder = MetricBuilder::new();
         let machine = MachineState::new();
-        let rlog = ReplicatedLog::new(node_id, old_members, io);
+        let rlog = ReplicatedLog::new(node_id, old_members, io, &metric_builder).expect("Never fails");
         Alive {
             logger,
             machine,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use prometrics;
 use std;
 use trackable::error::TrackableError;
 use trackable::error::{ErrorKind as TrackableErrorKind, ErrorKindExt};
@@ -7,6 +8,11 @@ use trackable::error::{ErrorKind as TrackableErrorKind, ErrorKindExt};
 pub struct Error(TrackableError<ErrorKind>);
 impl From<std::io::Error> for Error {
     fn from(f: std::io::Error) -> Self {
+        ErrorKind::Other.cause(f).into()
+    }
+}
+impl From<prometrics::Error> for Error {
+    fn from(f: prometrics::Error) -> Self {
         ErrorKind::Other.cause(f).into()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,17 +9,19 @@
 #[cfg(test)]
 extern crate fibers;
 extern crate futures;
+extern crate prometrics;
 #[macro_use]
 extern crate trackable;
 
 pub use error::{Error, ErrorKind};
 pub use io::Io;
-pub use replicated_log::{Event, ReplicatedLog};
+pub use replicated_log::{ComponentId, Event, ReplicatedLog};
 
 pub mod cluster;
 pub mod election;
 pub mod log;
 pub mod message;
+pub mod metrics;
 pub mod node;
 
 mod error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ extern crate trackable;
 
 pub use error::{Error, ErrorKind};
 pub use io::Io;
-pub use replicated_log::{ComponentId, Event, ReplicatedLog};
+pub use replicated_log::{Event, ReplicatedLog};
 
 pub mod cluster;
 pub mod election;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,117 @@
+//! raftlog のメトリクス。
+
+use prometrics::metrics::{Counter, Gauge, Histogram, HistogramBuilder, MetricBuilder};
+
+use node::NodeId;
+use {Error, Result};
+
+/// `raftlog` 全体に関するメトリクス。
+#[derive(Clone)]
+pub struct RaftlogMetrics {
+    pub(crate) node_state: NodeStateMetrics,
+}
+impl RaftlogMetrics {
+    pub(crate) fn new(builder: &MetricBuilder, node: &NodeId) -> Result<Self> {
+        let node_state = track!(NodeStateMetrics::new(builder, node))?;
+        Ok(Self { node_state })
+    }
+}
+
+/// ノード状態に関するメトリクス。
+#[derive(Clone)]
+pub struct NodeStateMetrics {
+    pub(crate) transit_to_candidate_total: Counter,
+    pub(crate) transit_to_follower_total: Counter,
+    pub(crate) transit_to_leader_total: Counter,
+    pub(crate) event_queue_len: Gauge,
+    pub(crate) poll_timeout_total: Counter,
+    pub(crate) candidate_to_leader_duration_seconds: Histogram,
+    pub(crate) candidate_to_follower_duration_seconds: Histogram,
+    pub(crate) loader_to_candidate_duration_seconds: Histogram,
+}
+impl NodeStateMetrics {
+    pub(crate) fn new(builder: &MetricBuilder, node: &NodeId) -> Result<Self> {
+        let node = node.as_str();
+        let mut builder: MetricBuilder = builder.clone();
+        builder.subsystem("node_state");
+        let transit_to_candidate_total = track!(builder
+            .counter("transit_to_candidate_total")
+            .help("Number of transitions to candidate role")
+            .label("node", &node)
+            .finish())?;
+        let transit_to_follower_total = track!(builder
+            .counter("transit_to_follower_total")
+            .help("Number of transitions to follower role")
+            .label("node", &node)
+            .finish())?;
+        let transit_to_leader_total = track!(builder
+            .counter("transit_to_leader_total")
+            .help("Number of transitions to leader role")
+            .label("node", &node)
+            .finish())?;
+        let event_queue_len = track!(builder
+            .gauge("event_queue_len")
+            .help("Length of a raft event queue")
+            .label("node", &node)
+            .finish())?;
+        let poll_timeout_total = track!(builder
+            .counter("poll_timeout_total")
+            .help("Number of timeout")
+            .label("node", &node)
+            .finish())?;
+        let candidate_to_leader_duration_seconds = track!(make_role_change_histogram(
+            builder
+                .histogram("candidate_to_leader_duration_seconds")
+                .help("Elapsed time moving from candidate to leader")
+                .label("node", &node)
+        ))?;
+        let candidate_to_follower_duration_seconds = track!(make_role_change_histogram(
+            builder
+                .histogram("candidate_to_follower_duration_seconds")
+                .help("Elapsed time moving from candidate to follower")
+                .label("node", &node)
+        ))?;
+        let loader_to_candidate_duration_seconds = track!(make_role_change_histogram(
+            builder
+                .histogram("loader_to_candidate_duration_seconds")
+                .help("Elapsed time moving from loader to candidate")
+                .label("node", &node)
+        ))?;
+        Ok(Self {
+            transit_to_candidate_total,
+            transit_to_follower_total,
+            transit_to_leader_total,
+            event_queue_len,
+            poll_timeout_total,
+            candidate_to_leader_duration_seconds,
+            candidate_to_follower_duration_seconds,
+            loader_to_candidate_duration_seconds,
+        })
+    }
+}
+
+fn make_role_change_histogram(builder: &mut HistogramBuilder) -> Result<Histogram> {
+    builder
+        .bucket(0.001)
+        .bucket(0.005)
+        .bucket(0.01)
+        .bucket(0.05)
+        .bucket(0.1)
+        .bucket(0.2)
+        .bucket(0.4)
+        .bucket(0.6)
+        .bucket(0.8)
+        .bucket(1.0)
+        .bucket(2.0)
+        .bucket(4.0)
+        .bucket(6.0)
+        .bucket(8.0)
+        .bucket(10.0)
+        .bucket(20.0)
+        .bucket(50.0)
+        .bucket(80.0)
+        .bucket(320.0)
+        .bucket(640.0)
+        .finish()
+        .map_err(|e| track!(Error::from(e)))
+}

--- a/src/node_state/common/mod.rs
+++ b/src/node_state/common/mod.rs
@@ -474,7 +474,7 @@ mod tests {
     #[test]
     fn is_snapshot_installing_works() -> TestResult {
         let node_id: NodeId = "node1".into();
-        let metrics = track!(NodeStateMetrics::new(&MetricBuilder::new(), &node_id))?;
+        let metrics = track!(NodeStateMetrics::new(&MetricBuilder::new()))?;
         let io = TestIoBuilder::new()
             .add_member(node_id.clone())
             .add_member("node2".into())
@@ -498,7 +498,7 @@ mod tests {
     #[test]
     fn is_focusing_on_installing_snapshot_works() -> TestResult {
         let node_id: NodeId = "node1".into();
-        let metrics = track!(NodeStateMetrics::new(&MetricBuilder::new(), &node_id))?;
+        let metrics = track!(NodeStateMetrics::new(&MetricBuilder::new()))?;
         let io = TestIoBuilder::new()
             .add_member(node_id.clone())
             .add_member("node2".into())

--- a/src/node_state/loader.rs
+++ b/src/node_state/loader.rs
@@ -114,7 +114,7 @@ mod tests {
     #[test]
     fn it_works() -> TestResult {
         let node_id: NodeId = "node1".into();
-        let metrics = track!(NodeStateMetrics::new(&MetricBuilder::new(), &node_id))?;
+        let metrics = track!(NodeStateMetrics::new(&MetricBuilder::new()))?;
         let io = TestIoBuilder::new().add_member(node_id.clone()).finish();
         let mut handle = io.handle();
         let cluster = io.cluster.clone();
@@ -165,7 +165,7 @@ mod tests {
     #[test]
     fn it_fails_if_log_suffix_contains_older_term() -> TestResult {
         let node_id: NodeId = "node1".into();
-        let metrics = track!(NodeStateMetrics::new(&MetricBuilder::new(), &node_id))?;
+        let metrics = track!(NodeStateMetrics::new(&MetricBuilder::new()))?;
         let io = TestIoBuilder::new().add_member(node_id.clone()).finish();
         let mut handle = io.handle();
         let cluster = io.cluster.clone();

--- a/src/node_state/loader.rs
+++ b/src/node_state/loader.rs
@@ -102,8 +102,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use prometrics::metrics::MetricBuilder;
+
     use election::Term;
     use log::{LogEntry, LogPosition, LogPrefix, LogSuffix};
+    use metrics::NodeStateMetrics;
     use node::NodeId;
     use test_util::tests::TestIoBuilder;
     use trackable::result::TestResult;
@@ -111,10 +114,11 @@ mod tests {
     #[test]
     fn it_works() -> TestResult {
         let node_id: NodeId = "node1".into();
+        let metrics = track!(NodeStateMetrics::new(&MetricBuilder::new(), &node_id))?;
         let io = TestIoBuilder::new().add_member(node_id.clone()).finish();
         let mut handle = io.handle();
         let cluster = io.cluster.clone();
-        let mut common = Common::new(node_id.clone(), io, cluster.clone());
+        let mut common = Common::new(node_id.clone(), io, cluster.clone(), metrics);
         let mut loader = Loader::new(&mut common);
 
         // prefix には空の snapshot があり、tail は 1 を指している。
@@ -161,10 +165,11 @@ mod tests {
     #[test]
     fn it_fails_if_log_suffix_contains_older_term() -> TestResult {
         let node_id: NodeId = "node1".into();
+        let metrics = track!(NodeStateMetrics::new(&MetricBuilder::new(), &node_id))?;
         let io = TestIoBuilder::new().add_member(node_id.clone()).finish();
         let mut handle = io.handle();
         let cluster = io.cluster.clone();
-        let mut common = Common::new(node_id.clone(), io, cluster.clone());
+        let mut common = Common::new(node_id.clone(), io, cluster.clone(), metrics);
         let mut loader = Loader::new(&mut common);
 
         // 古い term のログが紛れ込んでいるとエラーになる

--- a/src/node_state/mod.rs
+++ b/src/node_state/mod.rs
@@ -1,4 +1,5 @@
 use futures::{Async, Poll, Stream};
+use std::time::Instant;
 
 pub use self::common::Common;
 
@@ -9,6 +10,7 @@ use self::leader::Leader;
 use self::loader::Loader;
 use cluster::ClusterConfig;
 use message::Message;
+use metrics::NodeStateMetrics;
 use node::NodeId;
 use {Error, Event, Io, Result};
 
@@ -27,12 +29,20 @@ type NextState<IO> = Option<RoleState<IO>>;
 pub struct NodeState<IO: Io> {
     pub common: Common<IO>,
     pub role: RoleState<IO>,
+    started_at: Instant,
+    pub metrics: NodeStateMetrics,
 }
 impl<IO: Io> NodeState<IO> {
-    pub fn load(node_id: NodeId, config: ClusterConfig, io: IO) -> Self {
-        let mut common = Common::new(node_id, io, config);
+    pub fn load(node_id: NodeId, config: ClusterConfig, io: IO, metrics: NodeStateMetrics) -> Self {
+        let mut common = Common::new(node_id, io, config, metrics.clone());
         let role = RoleState::Loader(Loader::new(&mut common));
-        NodeState { common, role }
+        let started_at = Instant::now();
+        NodeState {
+            common,
+            role,
+            started_at,
+            metrics,
+        }
     }
     pub fn is_loading(&self) -> bool {
         self.role.is_loader()
@@ -40,7 +50,7 @@ impl<IO: Io> NodeState<IO> {
     pub fn start_election(&mut self) {
         if let RoleState::Follower(_) = self.role {
             let next = self.common.transit_to_candidate();
-            self.role = next;
+            self.handle_role_change(next);
         }
     }
     fn handle_timeout(&mut self) -> Result<Option<RoleState<IO>>> {
@@ -70,6 +80,38 @@ impl<IO: Io> NodeState<IO> {
             },
         }
     }
+    fn handle_role_change(&mut self, next: RoleState<IO>) {
+        // For now, we don't require the metrics of other state transitions.
+        match (&self.role, &next) {
+            (RoleState::Candidate(_), RoleState::Leader(_)) => {
+                let elapsed = prometrics::timestamp::duration_to_seconds(self.started_at.elapsed());
+                self.metrics
+                    .candidate_to_leader_duration_seconds
+                    .observe(elapsed);
+                self.started_at = Instant::now();
+            }
+            (RoleState::Candidate(_), RoleState::Follower(_)) => {
+                let elapsed = prometrics::timestamp::duration_to_seconds(self.started_at.elapsed());
+                self.metrics
+                    .candidate_to_follower_duration_seconds
+                    .observe(elapsed);
+                self.started_at = Instant::now();
+            }
+            (RoleState::Loader(_), RoleState::Candidate(_)) => {
+                let elapsed = prometrics::timestamp::duration_to_seconds(self.started_at.elapsed());
+                self.metrics
+                    .loader_to_candidate_duration_seconds
+                    .observe(elapsed);
+                self.started_at = Instant::now();
+            }
+            (RoleState::Leader(_), RoleState::Leader(_))
+            | (RoleState::Follower(_), RoleState::Follower(_))
+            | (RoleState::Candidate(_), RoleState::Candidate(_))
+            | (RoleState::Loader(_), RoleState::Loader(_)) => {}
+            _ => self.started_at = Instant::now(),
+        }
+        self.role = next;
+    }
 }
 impl<IO: Io> Stream for NodeState<IO> {
     type Item = Event;
@@ -78,7 +120,6 @@ impl<IO: Io> Stream for NodeState<IO> {
         let mut did_something = true;
         while did_something {
             did_something = false;
-
             // イベントチェック
             if let Some(e) = self.common.next_event() {
                 return Ok(Async::Ready(Some(e)));
@@ -87,8 +128,9 @@ impl<IO: Io> Stream for NodeState<IO> {
             // タイムアウト処理
             if let Async::Ready(()) = track!(self.common.poll_timeout())? {
                 did_something = true;
+                self.metrics.poll_timeout_total.increment();
                 if let Some(next) = track!(self.handle_timeout())? {
-                    self.role = next;
+                    self.handle_role_change(next);
                 }
                 if let Some(e) = self.common.next_event() {
                     return Ok(Async::Ready(Some(e)));
@@ -98,7 +140,7 @@ impl<IO: Io> Stream for NodeState<IO> {
             // 共通タスク
             if let Some(next) = track!(self.common.run_once())? {
                 did_something = true;
-                self.role = next;
+                self.handle_role_change(next);
             }
             if let Some(e) = self.common.next_event() {
                 return Ok(Async::Ready(Some(e)));
@@ -113,7 +155,7 @@ impl<IO: Io> Stream for NodeState<IO> {
             };
             if let Some(next) = result {
                 did_something = true;
-                self.role = next;
+                self.handle_role_change(next);
             }
             if let Some(e) = self.common.next_event() {
                 return Ok(Async::Ready(Some(e)));
@@ -123,7 +165,7 @@ impl<IO: Io> Stream for NodeState<IO> {
             if let Some(message) = track!(self.common.try_recv_message())? {
                 did_something = true;
                 if let Some(next) = track!(self.handle_message(message))? {
-                    self.role = next;
+                    self.handle_role_change(next);
                 }
                 if let Some(e) = self.common.next_event() {
                     return Ok(Async::Ready(Some(e)));
@@ -173,21 +215,27 @@ impl<IO: Io> RoleState<IO> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use prometrics::metrics::MetricBuilder;
+
     use test_util::tests::TestIoBuilder;
 
     #[test]
     fn node_state_is_loading_works() {
+        let metrics =
+            NodeStateMetrics::new(&MetricBuilder::new(), &"test".into()).expect("Never fails");
         let io = TestIoBuilder::new().finish();
         let cluster = io.cluster.clone();
-        let node = NodeState::load("test".into(), cluster, io);
+        let node = NodeState::load("test".into(), cluster, io, metrics);
         assert!(node.is_loading());
     }
 
     #[test]
     fn role_state_is_loader_works() {
+        let metrics =
+            NodeStateMetrics::new(&MetricBuilder::new(), &"test".into()).expect("Never fails");
         let io = TestIoBuilder::new().finish();
         let cluster = io.cluster.clone();
-        let mut common = Common::new("test".into(), io, cluster);
+        let mut common = Common::new("test".into(), io, cluster, metrics);
         let state = RoleState::Loader(Loader::new(&mut common));
         assert!(state.is_loader());
         assert!(!state.is_candidate());
@@ -195,9 +243,11 @@ mod tests {
 
     #[test]
     fn role_state_is_candidate_works() {
+        let metrics =
+            NodeStateMetrics::new(&MetricBuilder::new(), &"test".into()).expect("Never fails");
         let io = TestIoBuilder::new().finish();
         let cluster = io.cluster.clone();
-        let mut common = Common::new("test".into(), io, cluster);
+        let mut common = Common::new("test".into(), io, cluster, metrics);
         let state = RoleState::Candidate(Candidate::new(&mut common));
         assert!(!state.is_loader());
         assert!(state.is_candidate());

--- a/src/node_state/mod.rs
+++ b/src/node_state/mod.rs
@@ -221,8 +221,7 @@ mod tests {
 
     #[test]
     fn node_state_is_loading_works() {
-        let metrics =
-            NodeStateMetrics::new(&MetricBuilder::new(), &"test".into()).expect("Never fails");
+        let metrics = NodeStateMetrics::new(&MetricBuilder::new()).expect("Never fails");
         let io = TestIoBuilder::new().finish();
         let cluster = io.cluster.clone();
         let node = NodeState::load("test".into(), cluster, io, metrics);
@@ -231,8 +230,7 @@ mod tests {
 
     #[test]
     fn role_state_is_loader_works() {
-        let metrics =
-            NodeStateMetrics::new(&MetricBuilder::new(), &"test".into()).expect("Never fails");
+        let metrics = NodeStateMetrics::new(&MetricBuilder::new()).expect("Never fails");
         let io = TestIoBuilder::new().finish();
         let cluster = io.cluster.clone();
         let mut common = Common::new("test".into(), io, cluster, metrics);
@@ -243,8 +241,7 @@ mod tests {
 
     #[test]
     fn role_state_is_candidate_works() {
-        let metrics =
-            NodeStateMetrics::new(&MetricBuilder::new(), &"test".into()).expect("Never fails");
+        let metrics = NodeStateMetrics::new(&MetricBuilder::new()).expect("Never fails");
         let io = TestIoBuilder::new().finish();
         let cluster = io.cluster.clone();
         let mut common = Common::new("test".into(), io, cluster, metrics);

--- a/src/replicated_log.rs
+++ b/src/replicated_log.rs
@@ -1,4 +1,6 @@
 use futures::{Poll, Stream};
+use prometrics::metrics::MetricBuilder;
+use std::sync::Arc;
 use trackable::error::ErrorKindExt;
 
 use cluster::{ClusterConfig, ClusterMembers};
@@ -6,6 +8,7 @@ use election::{Ballot, Role};
 use io::Io;
 use log::{LogEntry, LogHistory, LogIndex, LogPosition, LogPrefix, ProposalId};
 use message::SequenceNumber;
+use metrics::RaftlogMetrics;
 use node::{Node, NodeId};
 use node_state::{NodeState, RoleState};
 use {Error, ErrorKind, Result};
@@ -26,6 +29,7 @@ use {Error, ErrorKind, Result};
 /// 不要になった`ReplicatedLog`インスタンスを回収することは可能.
 pub struct ReplicatedLog<IO: Io> {
     node: NodeState<IO>,
+    metrics: Arc<RaftlogMetrics>,
 }
 impl<IO: Io> ReplicatedLog<IO> {
     /// `members`で指定されたクラスタに属する`ReplicatedLog`のローカルインスタンス(ノード)を生成する.
@@ -43,10 +47,29 @@ impl<IO: Io> ReplicatedLog<IO> {
     /// また、以前のノードを再起動したい場合でも、もし永続ストレージが壊れている等の理由で、
     /// 前回の状態を正確に復元できないのであれば、
     /// ノード名を変更して、新規ノード追加扱いにした方が安全である.
-    pub fn new(node_id: NodeId, members: ClusterMembers, io: IO) -> Self {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(
+        component: ComponentId,
+        node_id: NodeId,
+        members: ClusterMembers,
+        io: IO,
+    ) -> Result<Self> {
         let config = ClusterConfig::new(members);
-        let node = NodeState::load(node_id, config, io);
-        ReplicatedLog { node }
+        let mut builder = MetricBuilder::new();
+        builder
+            .namespace("raftlog")
+            .label("component", &component.0);
+        let metrics = track!(RaftlogMetrics::new(&builder, &node_id))?;
+        let node = NodeState::load(node_id, config, io, metrics.node_state.clone());
+        Ok(ReplicatedLog {
+            node,
+            metrics: Arc::new(metrics),
+        })
+    }
+
+    /// `raftlog` のメトリクスを返す。
+    pub fn metrics(&self) -> &Arc<RaftlogMetrics> {
+        &self.metrics
     }
 
     /// 新しいコマンドを提案する.
@@ -295,4 +318,17 @@ pub enum Event {
     /// もし`new_head`の位置が、最新のコミット済み地点よりも
     /// 新しい場合には、これとは別に`SnapshotLoaded`イベントが発行される.
     SnapshotInstalled { new_head: LogPosition },
+}
+
+/// `ReplicatedLog` を使うコンポーネントを表すラベル.
+///
+/// ラベルはメトリクスに付与される。
+#[derive(Debug, Clone)]
+pub struct ComponentId(String);
+
+impl ComponentId {
+    /// Creates a new `ComponentId` instance.
+    pub fn new(id: &str) -> ComponentId {
+        Self(id.to_owned())
+    }
 }

--- a/src/replicated_log.rs
+++ b/src/replicated_log.rs
@@ -57,7 +57,7 @@ impl<IO: Io> ReplicatedLog<IO> {
         let config = ClusterConfig::new(members);
         let mut metric_builder = metric_builder.clone();
         metric_builder.namespace("raftlog");
-        let metrics = track!(RaftlogMetrics::new(&metric_builder, &node_id))?;
+        let metrics = track!(RaftlogMetrics::new(&metric_builder))?;
         let node = NodeState::load(node_id, config, io, metrics.node_state.clone());
         Ok(ReplicatedLog {
             node,


### PR DESCRIPTION
# Motivation

I'd like to collect metrics which describes how long it takes to elect a new leader when a term change happens.

# Changes

* Update version to `0.5.0` because this PR contains an incompatible API change.
* Come to use `prometrics` and add some metrics.

# Notes

I will create another PR for https://github.com/frugalos/raftlog_protobuf to use `raftlog 0.5.0`.