### PR TITLE
Bump the version to 0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raftlog"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["The FrugalOS Developers"]
 description = "An implementation of distributed replicated log based on the Raft algorithm"
 homepage = "https://github.com/frugalos/raftlog"


### PR DESCRIPTION
Change the version to 0.4.1 for preparing a new release of the frugalos (frugalos 0.11.0).

Changes after 0.4.0 are [here](https://github.com/frugalos/raftlog/compare/c0bd2d8...3ebb628) and the major change is [this commit](https://github.com/frugalos/raftlog/commit/208b69e8092f3fb19ed0306567c97741aa82cfb8
).
Especially, the following part, is important:
https://github.com/frugalos/raftlog/blob/208b69e8092f3fb19ed0306567c97741aa82cfb8/src/node_state/follower/init.rs#L48-L56