### PR TITLE
Notifies Event::NewLeaderElected when a new leader is elected

### DIFF
--- a/src/node_state/common/mod.rs
+++ b/src/node_state/common/mod.rs
@@ -174,6 +174,7 @@ where
     pub fn transit_to_leader(&mut self) -> RoleState<IO> {
         self.metrics.transit_to_leader_total.increment();
         self.set_role(Role::Leader);
+        self.notify_new_leader_elected();
         RoleState::Leader(Leader::new(self))
     }
 
@@ -202,7 +203,13 @@ where
         };
         self.set_ballot(new_ballot);
         self.set_role(Role::Follower);
+        self.notify_new_leader_elected();
         RoleState::Follower(Follower::new(self, pending_vote))
+    }
+
+    /// 新しいリーダーが選出されたことを通知する.
+    pub fn notify_new_leader_elected(&mut self) {
+        self.events.push_back(Event::NewLeaderElected);
     }
 
     /// 次のメッセージ送信に使用されるシーケンス番号を返す.

--- a/src/replicated_log.rs
+++ b/src/replicated_log.rs
@@ -293,6 +293,9 @@ pub enum Event {
     /// 新しい選挙期間に移った.
     TermChanged { new_ballot: Ballot },
 
+    /// 新しいリーダーが選出された.
+    NewLeaderElected,
+
     /// 新しいログエントリがコミットされた.
     ///
     /// エントリの内容がコマンドの場合には、


### PR DESCRIPTION
## Purpose

リーダーが変更された時に raftlog の利用者にイベントとしてリーダーを通知する。

`Event::NewLeaderElected` を追加することにより、`LogEntry::Noop` を待たずにフォロワーがリーダー決定を知ることができるようになる。

## Related Issue

https://github.com/frugalos/frugalos/issues/277