### PR TITLE
Fixes clippy warnings(clippy 0.0.212)

### DIFF
--- a/src/node_state/loader.rs
+++ b/src/node_state/loader.rs
@@ -185,7 +185,7 @@ mod tests {
             snapshot: vec![],
         });
         handle.set_initial_log_suffix(
-            suffix_head.clone(),
+            suffix_head,
             LogSuffix {
                 head: LogPosition {
                     prev_term: term,

--- a/src/node_state/mod.rs
+++ b/src/node_state/mod.rs
@@ -194,21 +194,13 @@ pub enum RoleState<IO: Io> {
 impl<IO: Io> RoleState<IO> {
     /// Returns true if this role state is `Loader`.
     pub fn is_loader(&self) -> bool {
-        if let RoleState::Loader(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, RoleState::Loader(_))
     }
 
     /// Returns true if this role state is `Candidate`.
     #[cfg(test)]
     pub fn is_candidate(&self) -> bool {
-        if let RoleState::Candidate(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, RoleState::Candidate(_))
     }
 }
 


### PR DESCRIPTION
This commit uses `matches!` to avoid the following warning:

```
error: if let .. else expression looks like `matches!` macro
   --> src/node_state/mod.rs:197:9
    |
197 | /         if let RoleState::Loader(_) = self {
198 | |             true
199 | |         } else {
200 | |             false
201 | |         }
```