### PR TITLE
suffixの明示的な削除コードを追加(issue18対策)

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -86,7 +86,6 @@ pub trait Io {
     /// ただし、`start`とは異なる位置から、エントリの取得を開始することは許可されない.
     fn load_log(&mut self, start: LogIndex, end: Option<LogIndex>) -> Self::LoadLog;
 
-
     /// ローカルログのうち末尾部分について、
     /// 指定された位置 `from` を含むそれ以降 [from..) を全て削除する.
     fn delete_suffix_from(&mut self, from: LogIndex) -> Self::DeleteLog;

--- a/src/io.rs
+++ b/src/io.rs
@@ -34,6 +34,9 @@ pub trait Io {
     /// ローカルログを取得するための`Future`.
     type LoadLog: Future<Item = Log, Error = Error>;
 
+    /// ローカルログの末尾部分を削除するための`Future`.
+    type DeleteLog: Future<Item = (), Error = Error>;
+
     /// タイムアウトを表現するための`Future`.
     type Timeout: Future<Item = (), Error = Error>;
 
@@ -82,6 +85,11 @@ pub trait Io {
     ///
     /// ただし、`start`とは異なる位置から、エントリの取得を開始することは許可されない.
     fn load_log(&mut self, start: LogIndex, end: Option<LogIndex>) -> Self::LoadLog;
+
+
+    /// ローカルログのうち末尾部分について、
+    /// 指定された位置 `from` を含むそれ以降 [from..) を全て削除する.
+    fn delete_suffix_from(&mut self, from: LogIndex) -> Self::DeleteLog;
 
     /// 選挙における役割に応じた時間のタイムアウトオブジェクトを生成する.
     fn create_timeout(&mut self, role: Role) -> Self::Timeout;

--- a/src/node_state/common/mod.rs
+++ b/src/node_state/common/mod.rs
@@ -238,6 +238,11 @@ where
         self.io.load_log(start, end)
     }
 
+    /// `from`以降のsuffixエントリ [from..) を削除する
+    pub fn delete_suffix_from(&mut self, from: LogIndex) -> IO::DeleteLog {
+        self.io.delete_suffix_from(from)
+    }
+
     /// ローカルログの末尾部分に`suffix`を追記する.
     pub fn save_log_suffix(&mut self, suffix: &LogSuffix) -> IO::SaveLog {
         self.io.save_log_suffix(suffix)

--- a/src/node_state/follower/delete.rs
+++ b/src/node_state/follower/delete.rs
@@ -10,7 +10,7 @@ use crate::{Io, Result};
 pub struct FollowerDelete<IO: Io> {
     future: IO::DeleteLog,
     from: LogPosition,
-    message: AppendEntriesCall,    
+    message: AppendEntriesCall,
 }
 impl<IO: Io> FollowerDelete<IO> {
     pub fn new(common: &mut Common<IO>, from: LogPosition, message: AppendEntriesCall) -> Self {
@@ -43,5 +43,136 @@ impl<IO: Io> FollowerDelete<IO> {
         } else {
             Ok(None)
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::test_dsl::dsl::*;
+
+    #[test]
+    #[rustfmt::skip]
+    fn delete_test_scenario1() {
+        use Command::*;
+        use LogEntry::*;
+
+        let a = NodeName(0);
+        let b = NodeName(1);
+        let c = NodeName(2);
+        let (mut service, _cluster) = build_complete_graph(&[a, b, c]);
+
+        interpret(
+            &vec![
+                RunAllUntilStabilize,
+                Timeout(a),
+                RunAllUntilStabilize,
+                // ここまでで a がリーダーになっている
+
+                // 実際にリーダーになっていることを確認する
+                Check(a, Pred::IsLeader),
+                Check(b, Pred::IsFollower),
+                Check(c, Pred::IsFollower),
+
+                RecvBan(a, b), RecvBan(a, c), // aはbからもcからも受け取らない
+                RecvBan(b, a), // bはaからは受け取らない
+                RecvBan(c, a), // cはaからは受け取らない
+
+                // aが孤立している状況で
+                // データをproposeすることで
+                // aにデータをためる
+                Propose(a), Propose(a), Propose(a),
+
+                // bとcは新しいTermへ移る準備(aのfollowを外す)
+                Timeout(b), Timeout(c), RunAllUntilStabilize,
+
+                // bを新しいリーダーにする
+                Timeout(b),
+
+                // bとcだけ適当な回数計算を進める
+                Step(b), Step(c),
+                Step(b), Step(c),
+                Step(b), Step(c),
+                Step(b), Step(c),
+                Step(b), Step(c),
+                Step(b), Step(c),
+
+                // cを独立させる
+                RecvBan(c, b),
+                RecvBan(c, a),
+                RunAllUntilStabilize,
+
+                // 想定している状況になっていることを確認する
+                Check(a, Pred::IsLeader),
+                Check(b, Pred::IsLeader),
+                Check(c, Pred::IsFollower),
+                Check(a, Pred::RawLogIs(0, 0, vec![Noop(2), Com(2), Com(2), Com(2)])),
+                Check(b, Pred::RawLogIs(0, 0, vec![Noop(2), Noop(4)])),
+                Check(c, Pred::RawLogIs(0, 0, vec![Noop(2)])), // Noop(4)がないことに注意
+
+                // a<->b は通信可能にする
+                RecvAllow(b, a),
+                RecvAllow(a, b),
+
+                // bからハートビートを送る
+                Heartbeat(b),
+                // メモリ上のlogとdisk上のlogにgapが生じるところまで進める
+                Step(b), Step(a),
+                Step(b), Step(a),
+                Step(b), Step(a),
+                Step(b), Step(a),
+
+                // これは a のメモリ上のlogの終端位置が
+                // 4にあって、その直前のtermが2であることを意味している
+                Check(a, Pred::HistoryTail(2, 4)),
+
+                // 一方で、既にDiskからは削除済みである
+                Check(a, Pred::RawLogIs(0, 0, vec![Noop(2)])),
+
+                // この状態のまま、aがタイムアウトしてしまうと
+                // 上の食い違った状態でleaderになろうとする。
+                //
+                // follower/mod.rs において handle_timeout で
+                // Delete中のタイムアウトは禁止している場合は
+                // このような場合を防ぐためであり、
+                // 以下のコードで問題は起きない。
+                //
+                // 一方で、タイムアウトを許す場合は
+                // 以下のコード（最後のStepAll）で問題が起こる。
+
+                // まず a<->c 間だけ通信を可能にする
+                RecvAllow(a, c),
+                RecvAllow(c, a),
+                RecvBan(b, a),
+                RecvBan(b, c),
+                RecvBan(c, b),
+                RecvBan(a, b),
+
+                // aとcをタイムアウトさせて十分に実行させることで
+                // 両者をcandidateにする
+                Timeout(a), Timeout(c), StepAll(100),
+
+                // そのあと、aがLeaderになれるようにTermを増やす手助け
+                Timeout(a),
+
+                // Delete中のタイムアウトを許していない場合 => aはfollowerのまま, cはcandidate
+                // Delete中のタイムアウトを許している場合 => a も c も candidate になる
+                //
+                // Delete中の「タイムアウトを許可している場合」は、
+                // aがleaderとなった後で、
+                // メモリ上のlogと実体との差に起因するエラーが生じる。
+                //
+                // 発生するエラーについて:
+                // 今回は `impl_io::over_write` で
+                // Disk上で「連続しないlog」を作成しようとしてエラーとなる。
+                //
+                // RaftlogではDisk上のlogは
+                // 論理上連続していることが仮定されているが
+                // (IO traitのload_log methodの引数を参照せよ）
+                // 仮にエラーとなる部分のassertionを外したとしても、
+                // 存在しない領域へのloadが発生し、どのみちエラーになる。
+                StepAll(100),
+            ],
+            &mut service
+        );
     }
 }

--- a/src/node_state/follower/delete.rs
+++ b/src/node_state/follower/delete.rs
@@ -1,0 +1,47 @@
+use futures::{Async, Future};
+
+use super::super::{Common, NextState, RoleState};
+use super::{Follower, FollowerIdle};
+use crate::log::LogPosition;
+use crate::message::{AppendEntriesCall, Message};
+use crate::{Io, Result};
+
+/// ローカルログの削除を行うサブ状態
+pub struct FollowerDelete<IO: Io> {
+    future: IO::DeleteLog,
+    from: LogPosition,
+    message: AppendEntriesCall,    
+}
+impl<IO: Io> FollowerDelete<IO> {
+    pub fn new(common: &mut Common<IO>, from: LogPosition, message: AppendEntriesCall) -> Self {
+        let future = common.delete_suffix_from(from.index);
+        FollowerDelete {
+            future,
+            from,
+            message,
+        }
+    }
+    pub fn handle_message(
+        &mut self,
+        common: &mut Common<IO>,
+        message: Message,
+    ) -> Result<NextState<IO>> {
+        if let Message::AppendEntriesCall(m) = message {
+            common.rpc_callee(&m.header).reply_busy();
+        }
+        Ok(None)
+    }
+    pub fn run_once(&mut self, common: &mut Common<IO>) -> Result<NextState<IO>> {
+        if let Async::Ready(_) = track!(self.future.poll())? {
+            track!(common.handle_log_rollbacked(self.from))?;
+            common
+                .rpc_callee(&self.message.header)
+                .reply_append_entries(self.from);
+
+            let next = Follower::Idle(FollowerIdle::new());
+            Ok(Some(RoleState::Follower(next)))
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/src/node_state/follower/idle.rs
+++ b/src/node_state/follower/idle.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 use trackable::error::ErrorKindExt;
 
 use super::super::{Common, NextState, RoleState};
-use super::{Follower, FollowerAppend, FollowerSnapshot, FollowerDelete};
+use super::{Follower, FollowerAppend, FollowerDelete, FollowerSnapshot};
 use crate::log::{LogPosition, LogSuffix};
 use crate::message::{AppendEntriesCall, Message};
 use crate::{ErrorKind, Io, Result};

--- a/src/node_state/follower/idle.rs
+++ b/src/node_state/follower/idle.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 use trackable::error::ErrorKindExt;
 
 use super::super::{Common, NextState, RoleState};
-use super::{Follower, FollowerAppend, FollowerSnapshot};
+use super::{Follower, FollowerAppend, FollowerSnapshot, FollowerDelete};
 use crate::log::{LogPosition, LogSuffix};
 use crate::message::{AppendEntriesCall, Message};
 use crate::{ErrorKind, Io, Result};
@@ -93,12 +93,8 @@ impl<IO: Io> FollowerIdle<IO> {
         if !matched {
             // 両者が分岐している
             // => ローカルログ(の未コミット領域)をロールバックして、同期位置まで戻る
-            let new_log_tail = lcp;
-            track!(common.handle_log_rollbacked(new_log_tail))?;
-            common
-                .rpc_callee(&message.header)
-                .reply_append_entries(new_log_tail);
-            Ok(None)
+            let next = FollowerDelete::new(common, lcp, message);
+            Ok(Some(RoleState::Follower(Follower::Delete(next))))
         } else {
             // 両者は包含関係にあるので、追記が可能
             track!(message.suffix.skip_to(lcp.index))?;

--- a/src/node_state/mod.rs
+++ b/src/node_state/mod.rs
@@ -48,9 +48,12 @@ impl<IO: Io> NodeState<IO> {
         self.role.is_loader()
     }
     pub fn start_election(&mut self) {
-        if let RoleState::Follower(_) = self.role {
-            let next = self.common.transit_to_candidate();
-            self.handle_role_change(next);
+        if let RoleState::Follower(follower) = &mut self.role {
+            let next = follower.handle_timeout(&mut self.common);
+            let next = track_try_unwrap!(next);
+            if let Some(next) = next {
+                self.handle_role_change(next);
+            }
         }
     }
     fn handle_timeout(&mut self) -> Result<Option<RoleState<IO>>> {

--- a/src/test_dsl/dsl.rs
+++ b/src/test_dsl/dsl.rs
@@ -3,8 +3,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::cluster::ClusterMembers;
-use crate::election::Role;
-use crate::log::{self, LogPosition};
+use crate::election::{Role, Term};
+use crate::log::{self, LogIndex, LogPosition};
 use crate::node::NodeId;
 use crate::test_dsl::impl_io::*;
 use crate::ReplicatedLog;
@@ -16,7 +16,7 @@ use std::fmt;
 /// DSL中でノード名を表すために用いる構造体
 /// 現時点ではu8のnewtypeに過ぎない
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
-pub struct NodeName(u8);
+pub struct NodeName(pub u8);
 
 impl fmt::Display for NodeName {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -67,6 +67,9 @@ pub enum Pred {
     /// 1. snapshotとrawlogが正しく接合している
     /// 2. rawlogのtermが昇順になっている
     LogTermConsistency,
+
+    /// Historyのtailを調べる
+    HistoryTail(u64 /* term */, u64 /* index */),
 }
 
 /// 引数`rlog`で表される特定のノードが、述語`pred`を満たすかどうかを調べる
@@ -115,8 +118,6 @@ fn check(rlog: &ReplicatedLog<TestIo>, pred: Pred) -> bool {
         }
         RawLogIs(term, index, entries) => {
             if let Some(rawlog) = &rlog.io().rawlog() {
-                dbg!(&rawlog);
-
                 let head: LogPosition = rawlog.head;
 
                 let head_check: bool = (head.prev_term.as_u64() == term as u64)
@@ -152,6 +153,13 @@ fn check(rlog: &ReplicatedLog<TestIo>, pred: Pred) -> bool {
                 false
             }
         }
+        HistoryTail(term, pos) => {
+            rlog.local_history().tail()
+                == LogPosition {
+                    prev_term: Term::new(term),
+                    index: LogIndex::new(pos),
+                }
+        }
     }
 }
 
@@ -183,6 +191,12 @@ pub enum Command {
 
     /// 指定されたノードを、raftlogの実装としての意味で1-stepだけ実行する
     Step(NodeName),
+
+    /// すべてのノードを、iter-step実行する。
+    /// この時ノードの実行はfairである。
+    /// すなわち各ノードをすべて1-step実行してから
+    /// 2-step目の実行を各ノードについて行い、その後で3-step目として実行していく。
+    StepAll(usize),
 
     /// 指定されたノードが、述語を満たすかどうかを検査する
     Check(NodeName, Pred),
@@ -219,7 +233,7 @@ pub fn interpret(cs: &[Command], service: &mut Service) {
 
 /// DSLの一つのコマンドを実行する関数
 fn interpret_command(c: Command, service: &mut Service) {
-    use crate::futures::Stream;
+    use futures::Stream;
     use Command::*;
 
     println!("\n Now executing {:?} ...", &c);
@@ -232,7 +246,7 @@ fn interpret_command(c: Command, service: &mut Service) {
         }
         Check(node, pred) => {
             let rlog = service.get_mut(&node).unwrap();
-            assert!(check(&rlog, pred));
+            assert!(check(rlog, pred));
         }
         Heartbeat(node) => {
             let rlog = service.get_mut(&node).unwrap();
@@ -247,6 +261,13 @@ fn interpret_command(c: Command, service: &mut Service) {
         }
         Step(node) => {
             service.get_mut(&node).unwrap().poll().unwrap();
+        }
+        StepAll(iter) => {
+            for _ in 0..iter {
+                for (_n, io) in service.iter_mut() {
+                    io.poll().expect("never fails in test senarios");
+                }
+            }
         }
         RunAllUntilStabilize => loop {
             let mut check = true;
@@ -313,10 +334,10 @@ pub fn build_complete_graph(names: &[NodeName]) -> (Service, ClusterMembers) {
     }
 
     for src in &nodes {
-        let mut io_src = ios.remove(&src).unwrap();
+        let mut io_src = ios.remove(src).unwrap();
         for dst in &nodes {
             if src != dst {
-                let io_dst = ios.get(&dst).unwrap();
+                let io_dst = ios.get(dst).unwrap();
                 io_src.set_channel(dst.clone(), io_dst.copy_sender());
             }
         }
@@ -338,10 +359,12 @@ pub fn build_complete_graph(names: &[NodeName]) -> (Service, ClusterMembers) {
 mod test {
     use super::*;
 
+    /// Logの削除処理を実装していない場合には、
     /// あるノードで、
     /// snapshot(prefix)の表す最終termと
     /// rawlog(suffix)の先頭エントリが期待するtermで
     /// ズレが生じる現象を再現させる。
+    /// （削除処理を実装している場合は問題ない）
     ///
     /// このテストではノードaでズレが生じるようにする。
     #[test]
@@ -380,7 +403,7 @@ mod test {
                 Timeout(b), Timeout(c),  RunAllUntilStabilize,
 
                 // bを新しいリーダーにする
-                Timeout(b), RunAllUntilStabilize,
+                Timeout(b), StepAll(100),
 
                 // 想定している状況になっていることを確認する
                 Check(a, Pred::IsLeader),
@@ -399,34 +422,36 @@ mod test {
                 RecvAllow(c, a),
 
                 // bからaとcへheartbeatを送る
-                Heartbeat(b), RunAllUntilStabilize,
+                Heartbeat(b), StepAll(100),
 
-                // aがstaleしていることがこの時点で判明して
-                // bのsnapshotがaに移る
-                // snapshotは、rawlog[2].term = 4 であることを要求しているが
-                Check(a, Pred::SnapShotIs(4 /* term */ , 2 /* index */)),
+                // **FollowerDeleteを実装している場合**
+                // 以下のように適切にログが整理される。
+                Check(a, Pred::SnapShotIs(4, 2)),
+                Check(a, Pred::RawLogIs(0, 0, vec![])),
 
-                // 一方でbのrawlogは、snapshotの保存にあたって先頭部分が削除され次のようになる
+                // **FollowerDeleteを実装していない場合（以前のraftlog）**
+                // aがstaleしていることがこの時点で判明してbのsnapshotがaに移る
+                // snapshotは、rawlog[2].term = 4 であることを要求する
+                // Check(a, Pred::SnapShotIs(4 /* term */ , 2 /* index */)),
+                //
+                // 一方でaのrawlogは、snapshotの保存にあたって先頭部分が削除され次のようになる
                 // snapshotの要求ではterm4から始まることになっているが、これに反する。
-                Check(a, Pred::RawLogIs(2, 2, vec![Com(2), Com(2), Com(2), Com(2)])),
-
+                // Check(a, Pred::RawLogIs(2, 2, vec![Com(2), Com(2), Com(2), Com(2)])),
+                //
                 // 最終的な確認として、Termの並びが"In"consistentであることを調べる。
-                Check(a, Pred::Not(Box::new(Pred::LogTermConsistency))),
-
-                // 不整合が実際に生じるのは、reboot時のエラーチェックである。
-                // panicを確認するには、次のコマンド2つを実行すれば良い。
-                // （既に直前のCheckで不整合が明らかになっているので実行しない）
-                // Reboot(a, _cluster), Step(a)
+                // Check(a, Pred::Not(Box::new(Pred::LogTermConsistency))),
             ],
             &mut service,
         );
     }
 
+    /// Logの削除処理を実装していない場合には、
     /// あるノードで,
     /// rawlogの一部分だけを書き換えた結果として、
     /// termの昇順整列制約が敗れることを確認する。
     /// 上のscenario1ではsnapshot, rawlog間でズレが生じていたが
     /// rawlog単体でもズレが生じることを示す。
+    /// （削除処理を実装している場合は問題ない）
     ///
     /// このテストではノードaで不整合が起こることを確認する。
     #[test]
@@ -463,9 +488,9 @@ mod test {
 
                 // bとcの間のやりとりで、bを新しいリーダーにする
                 Timeout(b), Timeout(c),
-                RunAllUntilStabilize,
+                StepAll(100),
                 Timeout(b), // b を leaderにする
-                RunAllUntilStabilize,
+                StepAll(100),
 
                 Check(a, Pred::IsLeader),
                 Check(b, Pred::IsLeader),
@@ -478,20 +503,21 @@ mod test {
                 RecvAllow(c, a),
 
                 // bからハートビートを送る
-                Heartbeat(b), RunAllUntilStabilize,
+                Heartbeat(b), StepAll(100),
 
                 // aがstaleしているため
-                // bの長さ2のrawlogにより上書きされるが
-                // rawlog[1].term = 4 と rawlog[2].term = 2 で
-                // 不整合が生じている
-                Check(a, Pred::RawLogIs(0, 0, vec![Noop(2), Noop(4), Com(2)])),
+                // bの長さ2のrawlogにより上書きされる。
 
-                // 最終的な確認として、Termの並びが"In"consistentであることを調べる。
-                Check(a, Pred::Not(Box::new(Pred::LogTermConsistency))),
+                // **FollowerDeleteを実装している場合**
+                // 以下のように適切にログが整理される。
+                Check(a, Pred::RawLogIs(0, 0, vec![Noop(2), Noop(4)])),
 
-                // この不整合は、実際にreboot処理を行うと
-                // raftlog内部でエラーになる
-                // Reboot(a, _cluster), Step(a),
+                // **FollowerDeleteを実装していない場合（以前のraftlog）**
+                // rawlog[1].term = 4 と rawlog[2].term = 2 で不整合が生じる
+                // Check(a, Pred::RawLogIs(0, 0, vec![Noop(2), Noop(4), Com(2)])),
+                //
+                // この時、Termの並びが"In"consistentになる。
+                // Check(a, Pred::Not(Box::new(Pred::LogTermConsistency))),
             ],
             &mut service,
         );

--- a/src/test_dsl/dsl.rs
+++ b/src/test_dsl/dsl.rs
@@ -265,7 +265,7 @@ fn interpret_command(c: Command, service: &mut Service) {
         StepAll(iter) => {
             for _ in 0..iter {
                 for (_n, io) in service.iter_mut() {
-                    io.poll().expect("never fails in test senarios");
+                    io.poll().expect("never fails in test scenarios");
                 }
             }
         }

--- a/src/test_dsl/impl_io.rs
+++ b/src/test_dsl/impl_io.rs
@@ -387,7 +387,7 @@ impl Io for TestIo {
             assert!(rawlog.head.index <= from);
             rawlog
                 .truncate(from)
-                .expect("should not make an error in test senarios");
+                .expect("should not make an error in test scenarios");
         } else {
             unreachable!("don't come here in test scenarios");
         }

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -109,6 +109,7 @@ pub mod tests {
         type SaveLog = NoopSaveLog;
         type LoadLog = LoadLogImpl;
         type Timeout = FibersTimeout;
+        type DeleteLog = NoopSaveLog;
 
         fn try_recv_message(&mut self) -> Result<Option<Message>> {
             Ok(None)
@@ -131,6 +132,10 @@ pub mod tests {
 
         fn save_log_suffix(&mut self, _suffix: &LogSuffix) -> Self::SaveLog {
             NoopSaveLog
+        }
+
+        fn delete_suffix_from(&mut self, _: LogIndex) -> Self::SaveLog {
+            panic!("do not use this in test codes OR please write the adequate code here");
         }
 
         fn load_log(&mut self, start: LogIndex, end: Option<LogIndex>) -> Self::LoadLog {


### PR DESCRIPTION
# PRの概要
Termがlog中で昇順に並ばないことがあるissue #18 を解決するためのコード群です。

ノード中のlogが古すぎる・staleしていて、ある位置 `x` のエントリがcommitすることがないことが判明した段階で、
suffix中のx以降のエントリ `[x..)` を全て削除するように変更します。

このPR以前では、ストレージ側にあるsuffixの削除は行っていないのですが、メモリ上のキャッシュに相当する[History](https://github.com/frugalos/raftlog/blob/12315643c559118dbe9c20625ff9e3c415bf9bb3/src/log/history.rs#L18-L23)では[削除を行っていました。](https://github.com/frugalos/raftlog/blob/12315643c559118dbe9c20625ff9e3c415bf9bb3/src/node_state/follower/idle.rs#L97)
これに一致するようにsuffixも削除するコードである、とも言えます。

別の説明としては、[Raftのオリジナル論文](https://raft.github.io/raft.pdf)において、
AppendEntriesRPCではstaleが判明した段階でエントリを削除するよう以下の指示があり、
> Receiver implementation:
> 1. Reply false if term < currentTerm (§5.1)
> 2. Reply false if log doesn’t contain an entry at prevLogIndex whose term matches prevLogTerm (§5.3)
> 3. If an existing entry conflicts with a new one (same index but different terms), delete the existing entry and all that follow it (§5.3)
> (Figure 2より抜粋）

論文と同じ振る舞いをするように修正する、とも言えます。

# コードの新規追加による修正箇所

新規追加による修正は大きく分けて以下の4つです。
1. Followerに新たなsubstate `FollowerDelete` を[追加しました](https://github.com/frugalos/raftlog/pull/42/files#diff-3d9c8662cb5185dd63ceefcd0c18d002f4ee74f76fcbbfdedb411b165fe1fa78)。
    * これは、上記概要に記載の通り、ログの一部分を削除するためのsubstateです。
2. 以前のコードで History に関する削除を行っていた箇所を、`FollowerDelete` 内に移動しました。
    * 具体的には、[この箇所](https://github.com/frugalos/raftlog/pull/42/files#diff-8073cd6e7e168378cd043552b044a613bcf80ede6b6d41eb32354b0b4a06abf8L96-L101) です。
3. 削除処理をIOのレイヤーに任せたいので、そのためのインタフェイスを追加しています:
    * 具体的には、[この箇所](https://github.com/frugalos/raftlog/pull/42/files#diff-76866598ce8fd16261a27ac58a84b2825e6e77fc37c163a6afa60f0f4477e569R89-R91) です。
4. Common構造体に、logに対する削除が実行中かどうかを表すフラグメンバを追加しました。
     * 具体的には[この箇所](https://github.com/frugalos/raftlog/pull/42/files#diff-c6428eda35c05b2579d830a895354cedecb35cbebf974799348f049553f88d5bR42)です。
     * このフラグは、下で見ますが、logとhistoryにズレがあるかどうかに対応しています。

# Issue18の解決に対応する修正内容・箇所について

Issue18はつまるところ「ストレージに永続化されているlogと、そのメモリ上のキャッシュに相当するhistoryに「ズレ」が生じている状態で計算を続けると、クラスタが不整合のある状態になる」と言えます。

このズレを解消する処理として今回新たにDeleteを導入します。

## Deleteの導入の有効性について
これまでDelete処理を行っていないために「logとhistoryにズレが発生し」そのまま計算を続けると問題が発生することを明らかにするテストケース [シナリオ1](https://github.com/frugalos/raftlog/blob/05c3d32159ebf47f7fc2e7a9ec8f4acbc7c927bb/src/test_dsl/dsl.rs#L349) と [シナリオ2](https://github.com/frugalos/raftlog/blob/05c3d32159ebf47f7fc2e7a9ec8f4acbc7c927bb/src/test_dsl/dsl.rs#L434) が既に存在していました。

このPRでのDeleteの導入によりlogとhistoryのズレが修正でき、上のテストケースが期待通りに動くことが確認できました。このことをもって、Deleteは有効であると言えます。
* 問題の解消に従い、正しく実行された際の期待挙動を実際にとることを確認するassertionに差し替えています。
[ここ](https://github.com/frugalos/raftlog/pull/42/files#diff-f97ba32726ee5b13a6ad09a264613ae6769a9934510f45a8faa18128dcd7ae1eR427-R430) と [ここ](https://github.com/frugalos/raftlog/pull/42/files#diff-f97ba32726ee5b13a6ad09a264613ae6769a9934510f45a8faa18128dcd7ae1eR511-R513) の周辺になります。
* 元のバグのある挙動はissue18の問題点を明らかにしていることを加味して、コメントアウトの形で残しています。
[ここ](https://github.com/frugalos/raftlog/pull/42/files#diff-f97ba32726ee5b13a6ad09a264613ae6769a9934510f45a8faa18128dcd7ae1eR432-L414) と [ここ](https://github.com/frugalos/raftlog/pull/42/files#diff-f97ba32726ee5b13a6ad09a264613ae6769a9934510f45a8faa18128dcd7ae1eR515-R520) です。

## 既存のコードに関して注意するべき点

Delete処理の導入だけでは、logとhistoryのズレを完全には解消できません。
なぜなら、Delete処理の途中で状態遷移を行うと、結局ズレが解消していないまま計算が続行されるからです。
（削除処理中に状態遷移をしてズレたまま計算すると、実際に問題が起こることについては、次のセクションで説明しています。）

これを防ぐために、**Delete処理が完了するまでは状態遷移をしない**ように、既存のコードも合わせて修正します。
修正箇所は以下の通りです:

1. Delete処理中にタイムアウトが発生しても、Candidateに即座に移行せずに、Deleteが完了するまでは処理を継続します。該当する箇所は[ここ](https://github.com/frugalos/raftlog/pull/42/files#diff-52bc37f619d478c21528f7fbc2a2d8262b8a690e31633a46428bb17731550451R46-R67)になっていて、内容としては:
    * タイムアウトが発生した場合には、その事実を記録しておき、Delete終了後にCandidateに遷移します。[該当する処理はこの部分です。](https://github.com/frugalos/raftlog/pull/42/files#diff-3d9c8662cb5185dd63ceefcd0c18d002f4ee74f76fcbbfdedb411b165fe1fa78R58-R60)
    * タイムアウトが発生しなかった場合には、通常の遷移と同じく、`FollowerIdle`に遷移します。[この箇所です。](https://github.com/frugalos/raftlog/pull/42/files#diff-3d9c8662cb5185dd63ceefcd0c18d002f4ee74f76fcbbfdedb411b165fe1fa78R61-R62)
2. Delete処理中には、受信メッセージの処理による状態遷移が発生しないようにしました。
    * そのようなことが起こるのは、自分のtermより大きなtermを含むメッセージが届いた場合なのですが、[その場合の遷移を防ぐコードがここになります。](https://github.com/frugalos/raftlog/pull/42/files#diff-c6428eda35c05b2579d830a895354cedecb35cbebf974799348f049553f88d5bR342-R348)
    * ズレが生じている場合にだけ遷移を防ぎたいので、`Common構造体`の中に、logの削除処理を実行中でhistoryにズレが生じていることを表すための[フラグメンバ](https://github.com/frugalos/raftlog/pull/42/files#diff-c6428eda35c05b2579d830a895354cedecb35cbebf974799348f049553f88d5bR31-R42)を追加しています。
    * このフラグは、[削除処理を開始してズレ始めたタイミングでセット](https://github.com/frugalos/raftlog/pull/42/files#diff-3d9c8662cb5185dd63ceefcd0c18d002f4ee74f76fcbbfdedb411b165fe1fa78R44)され、[削除処理が終了してhistoryも更新されてズレが解消されたタイミングでリセット](https://github.com/frugalos/raftlog/pull/42/files#diff-3d9c8662cb5185dd63ceefcd0c18d002f4ee74f76fcbbfdedb411b165fe1fa78R52)されます。
3. 手動でタイムアウトを強制的に発動させるメソッドの内部についても、遷移を引き起こす可能性があるので修正しました。
    * [この箇所です。](https://github.com/frugalos/raftlog/pull/42/files#diff-b293e1f45ef1b31f76a42877232fc756509a3ae6b290855b7758f79b44a944afR50-R58)
    * 以前のコードはFollowerなら即座にCandidateに遷移させるという、メソッド名と一致しないコードでした。
    これをより正確な実装である、Followerならばタイムアウトさせるメソッドを呼び出す、という実装に変更しています。
    * この変更は、既存のFollowerのsubstateに対しては意味を変えず、Deleteの場合にはCandidateへの遷移を遅らせるというという安全な実装になっています。

#  削除中のズレた状態で遷移すると発生する問題について
削除処理中に遷移すると実際に問題が生じることを述べた[テストコード](https://github.com/frugalos/raftlog/pull/42/files#diff-3d9c8662cb5185dd63ceefcd0c18d002f4ee74f76fcbbfdedb411b165fe1fa78R80)の内容を説明しているセクションです。
修正ではなくテストコードの説明を行っているセクションなので、skip可能です。

このテストコードでは次のような考え方をしています:
1. [タイムアウト判定処理](https://github.com/frugalos/raftlog/blob/05c3d32159ebf47f7fc2e7a9ec8f4acbc7c927bb/src/node_state/mod.rs#L129)が、[削除処理1stepの実行](https://github.com/frugalos/raftlog/pull/42/files#diff-3d9c8662cb5185dd63ceefcd0c18d002f4ee74f76fcbbfdedb411b165fe1fa78R46)に先行する（Followerのsubstateの処理はタイムアウト処理の後の[ここ](https://github.com/frugalos/raftlog/blob/05c3d32159ebf47f7fc2e7a9ec8f4acbc7c927bb/src/node_state/mod.rs#L152)から呼ばれます）ことに注目すると、
2. **もしタイムアウトによるCandidateへの遷移を許している場合は** たとえ削除処理が完了していたとしても、[この行に到達せずに](https://github.com/frugalos/raftlog/pull/42/files#diff-3d9c8662cb5185dd63ceefcd0c18d002f4ee74f76fcbbfdedb411b165fe1fa78R47) historyに反映されず、ズレた状態のcandidateが誕生する。より正確には、ストレージ上に存在しないエントリがhistory上では存在しているようにみえる。
3. 選挙に関してはhistoryの情報のみを参照して計算が進むので、このズレたCandidateがLeaderになりうる。

実際に、テストコードでは、Delete処理中に[logとhistoryが食い違った状況を作っています。](https://github.com/frugalos/raftlog/pull/42/files#diff-3d9c8662cb5185dd63ceefcd0c18d002f4ee74f76fcbbfdedb411b165fe1fa78R155-R164)
その後でDelete処理中のズレたままの状態で[タイムアウトを引き起こします。](https://github.com/frugalos/raftlog/pull/42/files#diff-3d9c8662cb5185dd63ceefcd0c18d002f4ee74f76fcbbfdedb411b165fe1fa78R185-R190)

この時、本PRでも採用しているように、削除中のタイムアウトによるCandidateへの遷移を防いでいる場合には問題は起こりません。

一方で、（PRのコードを修正して）削除中のタイムアウトによるCandidateへの即座の遷移を許す場合、ズレたCandidateがLeaderになるようなコードになっています。テストコードでは、リーダー選出直後の[Noopログエントリ](https://github.com/frugalos/raftlog/blob/05c3d32159ebf47f7fc2e7a9ec8f4acbc7c927bb/src/log/mod.rs#L204)の[書き込み](https://github.com/frugalos/raftlog/blob/05c3d32159ebf47f7fc2e7a9ec8f4acbc7c927bb/src/node_state/leader/mod.rs#L38-L43)を、History情報を用いてlogに追加しようとして、ストレージ視点でログの非連結状態を生み、エラーとなります。
* 図示すると次のような感じです:
   ```
    History: x x x x x x x y ← y が リーダー選出直後のエントリ
    Storage: x x . . . . . y ← . の位置は実際には削除されているエントリ（このような構造はLoaderの仮定としては許されていない）
    ```
